### PR TITLE
HTML output has doubled part header + already rendered plain-text mail overriden

### DIFF
--- a/lib/premailer-rails3/hook.rb
+++ b/lib/premailer-rails3/hook.rb
@@ -11,13 +11,16 @@ module PremailerRails
         # reset the body and add two new bodies with appropriate types
         message.body = nil
 
+        t_charset = message.charset
+
         message.html_part do
-          content_type "text/html; charset=utf-8"
+          content_type "text/html; charset=#{t_charset}"
           body premailer.to_inline_css
         end
 
         plain_text = premailer.to_plain_text if plain_text.blank?
         message.text_part do
+          content_type "text/plain; charset=#{t_charset}"
           body plain_text
         end
       end


### PR DESCRIPTION
On: rails-3.1.0-rc5, mail-2.3.0, premailer-1.7.1, hpricot-0.8.4
