### PR TITLE
Use asset.source instead of body in css_helper

### DIFF
--- a/lib/premailer-rails3/css_helper.rb
+++ b/lib/premailer-rails3/css_helper.rb
@@ -36,7 +36,7 @@ module PremailerRails
                      path.sub("#{Rails.configuration.assets.prefix}/", '')
                    end
             if asset = Rails.application.assets.find_asset(file)
-              asset.body
+              asset.respond_to?(:source) ? asset.source : asset.to_s
             else
               raise "Couldn't find asset #{file} for premailer-rails3."
             end


### PR DESCRIPTION
This should fix issue #17.

It is probably still imperfect, because it includes the css twice in dev mode:

Assuming `email/` directory contains one file `common.css`, and given the following file `email.css` :

```
/*
 * require_self
 * require_tree ./email/
 */
```
## In production mode

`stylesheet_link_tag 'email.css'` makes rails generate one file `email.css` which should contain all css files from `email` directory. Using the patch, they get included, everything is fine.
## In dev mode

`stylesheet_link_tag 'email.css'` makes rails include one `<link href="">` tag for each file (`email.css`, `email/common.css`)
When picked up by the css helper, both will have their full content included (including dependencies), so `common.css` ends up being added twice ...
