### PR TITLE
Strip asset digest from path in css_helper.

### DIFF
--- a/lib/premailer-rails3/css_helper.rb
+++ b/lib/premailer-rails3/css_helper.rb
@@ -33,7 +33,7 @@ module PremailerRails
             file = if path == :default
                      'email.css'
                    else
-                     path.sub("#{Rails.configuration.assets.prefix}/", '')
+                     path.sub("#{Rails.configuration.assets.prefix}/", '').sub(/(.*)-.*\.css$/, '\1.css')
                    end
             if asset = Rails.application.assets.find_asset(file)
               asset.body


### PR DESCRIPTION
With the asset pipeline enabled, find_asset(file) won't find the asset if the filename includes the asset digest.
