### PR TITLE
Nokogiri::XML::Attr and calling sub Ruby 1.9.3-p125

### DIFF
--- a/lib/premailer-rails3/css_helper.rb
+++ b/lib/premailer-rails3/css_helper.rb
@@ -33,7 +33,7 @@ module PremailerRails
             file = if path == :default
                      'email.css'
                    else
-                     path.sub("#{Rails.configuration.assets.prefix}/", '') \
+                     path.to_s.sub("#{Rails.configuration.assets.prefix}/", '') \
                          .sub(/-.*\.css$/, '.css')
                    end
             if asset = Rails.application.assets.find_asset(file)


### PR DESCRIPTION
As for me this can be Nokogiri::XML::Attr and we need to call explicitly to_s to be able to use sub method. Tested on 1.9.3-p125
