### PR TITLE
Prevent Nokogiri::XML::Attr object put into @@css_cache

### DIFF
--- a/lib/premailer-rails3/css_helper.rb
+++ b/lib/premailer-rails3/css_helper.rb
@@ -6,7 +6,7 @@ module PremailerRails
 
     def css_for_doc(doc)
       css = doc.search('link[@type="text/css"]').map { |link|
-              url = link.attributes['href']
+              url = link.attributes['href'].to_s
               load_css_at_path(url) unless url.blank?
             }.reject(&:blank?).join("\n")
       css = load_css_at_path(:default) if css.blank?


### PR DESCRIPTION
Prevent Nokogiri::XML::Attr object put into @@css_cache -> it had each time diff object_id, so it was never finded in @@css_cache again. Now there is inserted only name of css file.
