### PR TITLE
Fixes #21

### DIFF
--- a/lib/premailer-rails3/hook.rb
+++ b/lib/premailer-rails3/hook.rb
@@ -19,15 +19,42 @@ module PremailerRails
         # IMPORTANT: Plain text part must be generated before CSS is inlined.
         # Not doing so results in CSS declarations visible in the plain text
         # part.
-        message.text_part do
-          content_type "text/plain; charset=#{charset}"
-          body premailer.to_plain_text
-        end unless message.text_part
 
-        message.html_part do
-          content_type "text/html; charset=#{charset}"
-          body premailer.to_inline_css
+        unless message.text_part
+          text_part = {
+            :content_type => "text/plain; charset=#{charset}",
+            :body => premailer.to_plain_text
+          }
         end
+
+        html_part = {
+          :content_type => "text/html; charset=#{charset}",
+          :body => premailer.to_inline_css
+        }
+
+        if message.text_part && message.html_part
+          message.html_part.body = html_part[:body]
+          message.html_part.content_type = html_part[:content_type]
+
+        elsif message.html_part
+          message.parts.delete_if { |p| p.mime_type == 'text/html' && !p.attachment? }
+
+          message.part :content_type => "multipart/alternative", :content_disposition => "inline" do |p|
+            p.part text_part
+            p.part html_part
+          end
+        else
+          message.text_part do
+            body text_part[:body]
+            content_type text_part[:content_type]
+          end
+
+          message.html_part do
+            body html_part[:body]
+            content_type html_part[:content_type]
+          end
+        end
+
       end
     end
   end


### PR DESCRIPTION
Hello Philipe,

I've made a quick fix for #21 bug. This workes for me, although I feel there can be situations with complex nested multipart hierarchies where it won't work. Anyway take a look at pull request please

Also in this tree, the root node can be "multipart/related" (for inline attachments):

```
+ multipart/mixed
|
+--+ attachment
|
+--+ multipart/alternative
   |
   +--+ text/html
   |
   +--+ text/plain
```

Regards,
Dmitry
