### PR TITLE
Test for default file to clean up specs output

### DIFF
--- a/lib/premailer-rails3/css_helper.rb
+++ b/lib/premailer-rails3/css_helper.rb
@@ -46,7 +46,8 @@ module PremailerRails
             end
           else
             file = path == :default ? '/stylesheets/email.css' : path
-            File.read("#{Rails.root}/public#{file}")
+            css_file = "#{Rails.root}/public#{file}"
+            File.exist?(css_file) ? File.read(css_file) : ""
           end
       end
 


### PR DESCRIPTION
If no CSS files are specified we attempt to load in the default
stylesheet, which defaults to "/stylesheets/email.css". Since this file
may or may not exist in every Rails app, its existance should be
verified before attempting to read it.

This dies silently if the file does not actually exist, but when running
mailer specs it clutters the output significantly as File continually
warns you about the nonexistance of email.css
