### PR TITLE
Preserve single-part text/html messages

### DIFF
--- a/lib/premailer-rails3/hook.rb
+++ b/lib/premailer-rails3/hook.rb
@@ -18,7 +18,7 @@ module PremailerRails
         charset   = message.charset
 
         if multipart
-          # IMPRTANT: Plain text part must be generated before CSS is inlined.
+          # IMPORTANT: Plain text part must be generated before CSS is inlined.
           # Not doing so results in CSS declarations visible in the plain text
           # part.
           message.text_part do


### PR DESCRIPTION
Only add a text part if the message was already multipart. This fixes sending of HTML email to services that don't support multipart messages.

I also fixed a typo while I was at it.
