### PR TITLE
Set a default `input_encoding` of UTF-8 when initializing.

### DIFF
--- a/lib/premailer-rails3/premailer.rb
+++ b/lib/premailer-rails3/premailer.rb
@@ -7,7 +7,10 @@ module PremailerRails
       # suitable adaptor (Nokogiri or Hpricot). To make load_html work, an
       # adaptor needs to be included and @options[:with_html_string] needs to be
       # set. For further information, refer to ::Premailer#initialize.
-      @options = { :with_html_string => true }
+      @options = {
+        :with_html_string => true,
+        :input_encoding => 'UTF-8'
+      }
       ::Premailer.send(:include, Adapter.find(Adapter.use))
       doc = load_html(html)
 


### PR DESCRIPTION
This is a new, required option for the latest version of `premailer`. They are yet to release a new version of the gem (annoying) but the changes allow you to set an encoding which helps address several encoding-related bugs (e.g. https://github.com/alexdunae/premailer/issues/92)

For those not using the edge version, I believe the config option will be silently ignored.
