### PR TITLE
nil Exception When Absolute or Relative URL is Used Without Query String or http:// 

### DIFF
--- a/lib/premailer-rails3/css_helper.rb
+++ b/lib/premailer-rails3/css_helper.rb
@@ -53,9 +53,9 @@ module PremailerRails
         url = url[0..(url.index('?') - 1)] if url.include? '?'
         # Remove the host
         url = url.sub(/^https?\:\/\/[^\/]*/, '') if url.index('http') == 0
-      else
-        url
       end
+
+      url
     end
   end
 end


### PR DESCRIPTION
The following stylesheet links will cause errors with 1.3.0 (but not 1.2.x) if a query string or http:// is not included in URL:

```
<link rel="stylesheet" type="text/css" href="/assets/store/email.css" />
<link rel="stylesheet" type="text/css" href="core/email.css" />
```
