### PR TITLE
Use precompiled assets if present

### DIFF
--- a/spec/premailer-rails3/css_helper_spec.rb
+++ b/spec/premailer-rails3/css_helper_spec.rb
@@ -127,6 +127,7 @@ describe PremailerRails::CSSHelper do
     end
 
     context 'when Rails asset pipeline is used' do
+
       before {
         Rails.configuration.stubs(:assets).returns(
           stub(
@@ -134,6 +135,7 @@ describe PremailerRails::CSSHelper do
             :prefix  => '/assets'
           )
         )
+        PremailerRails::CSSLoaders::AssetPipelineLoader.stubs(:assets_precompiled?).returns(false)
       }
 
       it 'should load email.css when the default CSS is requested' do
@@ -199,6 +201,20 @@ describe PremailerRails::CSSHelper do
           load_css(
             'http://example.com/assets/base-089e35bd5d84297b8d31ad552e433275.css'
           ).should == 'content of base.css'
+        end
+      end
+
+      context 'when assets are precompiled' do
+        before {
+          PremailerRails::CSSLoaders::AssetPipelineLoader.stubs(:assets_precompiled?).returns(true)
+        }
+
+        it 'should load precompiled assets from the filesystem' do
+          File.expects(:read) \
+              .with('RAILS_ROOT/public/somewhere/on/the/disk/precompiled.css') \
+              .returns('content of compiled css')
+
+          load_css('precompiled.css').should == 'content of compiled css'
         end
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,4 @@
+require 'stubs/action_controller'
 require 'stubs/action_mailer'
 require 'stubs/rails'
 require 'stubs/hassle'

--- a/spec/stubs/action_controller.rb
+++ b/spec/stubs/action_controller.rb
@@ -1,0 +1,14 @@
+# ActionController::Base.helpers.asset_path(file)
+module ActionController
+  module FakeHelpers
+    def self.asset_path(file)
+      'somewhere/on/the/disk/' + file
+    end
+  end
+
+  module Base
+    def self.helpers
+      FakeHelpers
+    end
+  end
+end

--- a/spec/stubs/rails.rb
+++ b/spec/stubs/rails.rb
@@ -57,6 +57,10 @@ module Rails
     Logger
   end
 
+  def public_path
+    File.join(root, 'public')
+  end
+
   def root
     'RAILS_ROOT'
   end


### PR DESCRIPTION
This change uses precompiled assets if they are available.

The prior behavior was to ask the asset pipeline to compile the asset each time, which is what `Rails.application.assets.find_asset` unfortunately does.

Adding this feature allows premailer-rails3 to work correctly when assets are precompiled and all asset-compilation gems are included only in the `:assets` group in the bundle. 

Without this change, I have to include sass in my production slug on Heroku or I get an error: `uninitialized constant Sass::VERSION`. 
