### PR TITLE
Add ability to skip premailer

### DIFF
--- a/lib/premailer/rails/hook.rb
+++ b/lib/premailer/rails/hook.rb
@@ -12,14 +12,25 @@ class Premailer
       end
 
       def perform
-        if message_contains_html?
+        if !skip_premailer? && message_contains_html?
           replace_html_part(generate_html_part_replacement)
         end
 
+        remove_skip_header
         message
       end
 
       private
+      SKIP_HEADER = "premailer"
+      SKIP_VALUES = ['off', 'false']
+      def skip_premailer?
+        skip_header_field = message[SKIP_HEADER]
+        skip_header_field && SKIP_VALUES.include?(skip_header_field.value)
+      end
+
+      def remove_skip_header
+        message.header.fields.delete_if{|n| n.name == SKIP_HEADER }
+      end
 
       def message_contains_html?
         html_part.present?

--- a/spec/lib/hook_spec.rb
+++ b/spec/lib/hook_spec.rb
@@ -74,4 +74,19 @@ describe Premailer::Rails::Hook do
       processed_message.parts.last.content_type.should include 'image/png'
     end
   end
+
+  context 'when message disables premailer' do
+    it 'does not change the body of a html message' do
+      message[:premailer] = 'off'
+      expect { run_hook(message) }.to_not change(message, :body)
+      message[:premailer].should be_nil
+    end
+
+    it 'does not change the html of a multipart message' do
+      message = Fixtures::Message.with_parts(:html, :text)
+      message[:premailer] = 'off'
+      expect { run_hook(message) }.to_not change(message, :html_part)
+      message[:premailer].should be_nil
+    end
+  end
 end


### PR DESCRIPTION
Skip transforming message when the header[:premailer]  is set to 'off' or 'false'.

The strings ('off' or 'false') were required, because the mail gem converted `message[:premailer] = false` into a premailer header w\ a nil value.
