### PR TITLE
Update documentation to reflect that email.css is no longer autoloaded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 - Add support for precompiled assets
 
+- Remove autoloading of default stylesheet (email.css)
+
 ## v1.1.0
 
 - Fixed several bugs

--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ If both are loaded for some reason, premailer chooses hpricot.
 
 That's it!
 
+Note: If you are upgrading from 1.1.0, you'll need to include email.css in your templates, as it is no longer autoloaded.
+
 ## Configuration
 
 Premailer itself accepts a number of options. In order for premailer-rails to


### PR DESCRIPTION
Associated issue: https://github.com/fphilipe/premailer-rails/issues/49#issuecomment-16526145
