### PR TITLE
Fix digest regex so other hyphenated files do not fail to load

### DIFF
--- a/lib/premailer/rails/css_loaders.rb
+++ b/lib/premailer/rails/css_loaders.rb
@@ -33,7 +33,7 @@ class Premailer
 
         def file_name(path)
           path.sub("#{::Rails.configuration.assets.prefix}/", '') \
-            .sub(/-.*\.css$/, '.css')
+            .sub(/-[0-9a-f]{32}\.css$/, '.css')
         end
 
         def request_and_unzip(file)


### PR DESCRIPTION
This prevents stylesheets with hyphenated filenames failing to load, due to the filename being detected incorrectly, e.g. "assets/my-stylesheet.css" => "my.css".
