### PR TITLE
Improve assets fetching algorithm

### DIFF
--- a/lib/premailer/rails/css_helper.rb
+++ b/lib/premailer/rails/css_helper.rb
@@ -30,25 +30,13 @@ class Premailer
       end
 
       def load_css(url)
-        path = extract_path(url)
 
-        @cache[path] = STRATEGIES.each do |strategy|
-                         css = strategy.load(path)
+        @cache[url] = STRATEGIES.each do |strategy|
+                         css = strategy.load(url)
                          break css if css
                        end
       end
 
-      # Extracts the path of a url.
-      def extract_path(url)
-        if url.is_a? String
-          # Remove everything after ? including ?
-          url = url[0..(url.index('?') - 1)] if url.include? '?'
-          # Remove the host
-          url = url.sub(/^https?\:\/\/[^\/]*/, '') if url.index('http') == 0
-        end
-
-        url
-      end
     end
   end
 end

--- a/spec/lib/css_helper_spec.rb
+++ b/spec/lib/css_helper_spec.rb
@@ -55,7 +55,7 @@ describe Premailer::Rails::CSSHelper do
       it 'should return the cached value' do
         cache =
           Premailer::Rails::CSSHelper.send(:instance_variable_get, '@cache')
-        cache['/stylesheets/base.css'] = 'content of base.css'
+        cache['http://example.com/stylesheets/base.css'] = 'content of base.css'
 
         load_css('http://example.com/stylesheets/base.css')
           .should == 'content of base.css'
@@ -133,18 +133,35 @@ describe Premailer::Rails::CSSHelper do
           Kernel.expects(:open).with(url).returns(string_io)
 
           load_css(
-            'http://example.com/assets/base.css'
-          ).should == 'content of base.css'
-        end
-
-        it 'should request the same file when path contains file fingerprint' do
-          Kernel.expects(:open).with(url).returns(string_io)
-
-          load_css(
             'http://example.com/assets/base-089e35bd5d84297b8d31ad552e433275.css'
           ).should == 'content of base.css'
         end
+
+        context "when asset url has no protocol" do
+          let(:url) {
+            "http://example.com/assets/base.css"
+          }
+          it "should prepend http protocol" do
+            Kernel.expects(:open).with(url).returns(string_io)
+            load_css(
+              '//example.com/assets/base.css'
+            ).should == "content of base.css"
+          end
+        end
+
+        context "when asset host is given explicitly" do
+          let(:url) {
+            "http://myhost.com/assets/base.css"
+          }
+          it "should just request given url" do
+            Kernel.expects(:open).with(url).returns(string_io)
+            load_css(
+              url
+            ).should == "content of base.css"
+          end
+        end
       end
+
     end
 
     context 'when static stylesheets are used' do


### PR DESCRIPTION
Current way of fetching CSS doesn't seem good enough.

When there the url is given explicitly it should not append a digest.
That's why `http://example.com/assets/base.css` should not be changed to
`http://example.com/assets/base-089e35bd5d84297b8d31ad552e433275.css`
(related test deleted). As asset with digest might not exist.

There should be an ability to load css from different host
url than the one in asset_host in rails config.

Also asset_host could be specified without protocol:
`//example.com`.
http://stackoverflow.com/questions/9161769/url-without-httphttps
This case should be supported when fetching asset with http
