### PR TITLE
Specs for CssLoader.file_name, tests correct fingerprint cutting

### DIFF
--- a/spec/lib/css_loaders_spec.rb
+++ b/spec/lib/css_loaders_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+
+describe Premailer::Rails::CSSLoaders::AssetPipelineLoader do
+  before { Rails.stubs(:configuration).returns stub(assets: stub(prefix: '/assets')) }
+
+  describe ".file_name" do
+    subject { Premailer::Rails::CSSLoaders::AssetPipelineLoader.file_name asset }
+
+    context "when asset file path contains prefix" do
+      let(:asset) { '/assets/application.css' }
+      it { should == 'application.css' }
+    end
+
+    context "when asset file path contains fingerprint" do
+      let(:asset) { 'application-6776f581a4329e299531e1d52aa59832.css' }
+      it { should == 'application.css' }
+    end
+
+    context "when asset file page contains numbers, but not a fingerprint" do
+      let(:asset) { 'test/20130708152545-foo-bar.css' }
+      it { should == "test/20130708152545-foo-bar.css" }
+    end
+  end
+end


### PR DESCRIPTION
**premailer-rails** latest version on rubygems has an issue. If asset file name contains any digits, but not a fingerprint then `CssLoader` changes file name. For example if I have asset with file path `company-4567.css` then after passing through `CssLoader.file_name` it changes asset file name to `company.css` which is not correct.

I see that you fixed this issue in master branch already. So my fix is not needed, but I also added some specs to prevent this issue happens in future versions.
