### PR TITLE
Remove rails dependency

### DIFF
--- a/premailer-rails.gemspec
+++ b/premailer-rails.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'premailer', '~> 1.7'
 
+  s.add_development_dependency 'actionmailer', '>= 3'
   s.add_development_dependency 'rspec-core'
   s.add_development_dependency 'rspec-expectations'
   s.add_development_dependency 'mocha'


### PR DESCRIPTION
## Not _Rails_ dependency

By removing the `rails` dependency on your _gemspec_ file, the project using `premailer-rails` gem won't update it's _rails_ major, minor, patch version by just installing the last _premailer-rails_ version available (i.e using `bundle update premailer-rails`for example).
This are good practices used in projects like [devise](https://github.com/plataformatec/devise).
