### PR TITLE
Prefer precompiled assets over the pipeline

### DIFF
--- a/lib/premailer/rails/css_helper.rb
+++ b/lib/premailer/rails/css_helper.rb
@@ -11,8 +11,8 @@ class Premailer
 
       STRATEGIES = [
         CSSLoaders::CacheLoader,
-        CSSLoaders::AssetPipelineLoader,
-        CSSLoaders::FileSystemLoader
+        CSSLoaders::FileSystemLoader,
+        CSSLoaders::AssetPipelineLoader
       ]
 
       # Returns all linked CSS files concatenated as string.

--- a/lib/premailer/rails/css_loaders.rb
+++ b/lib/premailer/rails/css_loaders.rb
@@ -60,6 +60,8 @@ class Premailer
 
         def load(path)
           File.read("#{::Rails.root}/public#{path}")
+        rescue Errno::ENOENT # File not found
+          nil
         end
       end
     end

--- a/spec/lib/css_helper_spec.rb
+++ b/spec/lib/css_helper_spec.rb
@@ -87,6 +87,12 @@ describe Premailer::Rails::CSSHelper do
         )
       }
 
+      it 'should return the precompiled file before attempting to use pipeline' do
+        path = "email-digest.css"
+        File.expects(:read).with("#{::Rails.root}/public#{path}").returns 'read from file'
+        load_css(path).should == 'read from file'
+      end
+
       it 'should return the content of the file compiled by Rails' do
         Rails.application.assets
           .expects(:find_asset)


### PR DESCRIPTION
This alters the order of loaders so that the
assets are loaded from file system first and
only then, if failed, try to use the pipeline.

This should solve the problems with Rails 4
which always has the assets pipeline enabled
and thus always uses pipeline to precompile assets
instead of picking up ready-to go files.

This commit will also resolve the issue for those
who choose not to run full `assets` group in production
to save tons of memory.
(More at
https://github.com/rails/rails/commit/49c4af43ec5819d8f5c1a91f9b84296c927ce6e7#commitcomment-4544418)

This PR seem to resolve other issue like #64, #50, #55 etc.
