### PR TITLE
removes RAILS_RELATIVE_URL_ROOT from the file name

### DIFF
--- a/lib/premailer/rails/css_loaders/asset_pipeline_loader.rb
+++ b/lib/premailer/rails/css_loaders/asset_pipeline_loader.rb
@@ -17,9 +17,11 @@ class Premailer
         end
 
         def file_name(url)
-          URI(url).path
+          path = URI(url).path
             .sub("#{::Rails.configuration.assets.prefix}/", '')
             .sub(/-\h{32}\.css$/, '.css')
+          path.sub!(ENV['RAILS_RELATIVE_URL_ROOT'], '') if ENV['RAILS_RELATIVE_URL_ROOT']
+          path
         end
       end
     end

--- a/spec/unit/css_loaders/asset_pipeline_loader_spec.rb
+++ b/spec/unit/css_loaders/asset_pipeline_loader_spec.rb
@@ -26,5 +26,13 @@ describe Premailer::Rails::CSSLoaders::AssetPipelineLoader do
       let(:asset) { 'test/20130708152545-foo-bar.css' }
       it { should == "test/20130708152545-foo-bar.css" }
     end
+
+    context "when asset file page contains RAILS_RELATIVE_URL_ROOT" do
+      before do
+         ENV['RAILS_RELATIVE_URL_ROOT'] = '/development'
+      end
+      let(:asset) { "#{ENV['RAILS_RELATIVE_URL_ROOT']}foo-bar.css" }
+      it { should == "foo-bar.css" }
+    end
   end
 end


### PR DESCRIPTION
When using a RAILS_RELATIVE_URL_ROOT the AssetPipelineLoader cannot find the file. This change will remove the url root.