### PR TITLE
asset_pipline_loader

### DIFF
--- a/lib/premailer/rails/css_loaders/asset_pipeline_loader.rb
+++ b/lib/premailer/rails/css_loaders/asset_pipeline_loader.rb
@@ -13,7 +13,7 @@ class Premailer
         end
 
         def asset_pipeline_present?
-          defined?(::Rails) and ::Rails.application.respond_to?(:assets)
+          (defined?(::Rails) and ::Rails.application.respond_to?(:assets) and !::Rails.application.assets.nil?)
         end
 
         def file_name(url)

--- a/spec/unit/css_loaders/asset_pipeline_loader_spec.rb
+++ b/spec/unit/css_loaders/asset_pipeline_loader_spec.rb
@@ -1,13 +1,14 @@
 require 'spec_helper'
 
 describe Premailer::Rails::CSSLoaders::AssetPipelineLoader do
-  before do
-    assets = double(prefix: '/assets')
-    config = double(assets: assets)
-    allow(Rails).to receive(:configuration).and_return(config)
-  end
 
   describe ".file_name" do
+    before do
+      assets = double(prefix: '/assets')
+      config = double(assets: assets)
+      allow(Rails).to receive(:configuration).and_return(config)
+    end
+
     subject do
       Premailer::Rails::CSSLoaders::AssetPipelineLoader.file_name(asset)
     end
@@ -26,5 +27,22 @@ describe Premailer::Rails::CSSLoaders::AssetPipelineLoader do
       let(:asset) { 'test/20130708152545-foo-bar.css' }
       it { should == "test/20130708152545-foo-bar.css" }
     end
+
+  end
+
+  describe "no assets" do
+    before do
+      application = double(assets: nil)
+      allow(Rails).to receive(:application).and_return(application)
+    end
+
+    subject do
+      Premailer::Rails::CSSLoaders::AssetPipelineLoader.asset_pipeline_present?
+    end
+
+    context "when assets are not enabled" do
+      it { should == false }
+    end
+
   end
 end


### PR DESCRIPTION
Local Rails 3.2.17 app w/ asset pipeline disabled, Ruby 2.0.0-p451, was failing spec tests with undefined method `find_asset' for nil:NilClass. Noted that Rails.application.assets is defined, but nil in that case. Updated asset_pipeline_loader to check for nil? and updated test.