### PR TITLE
Removing excess slash from filename for pipeline find

### DIFF
--- a/lib/premailer/rails/css_loaders/asset_pipeline_loader.rb
+++ b/lib/premailer/rails/css_loaders/asset_pipeline_loader.rb
@@ -19,7 +19,7 @@ class Premailer
         def file_name(url)
           URI(url).path
             .sub("#{::Rails.configuration.assets.prefix}/", '')
-            .sub(/-\h{32}\.css$/, '.css')
+            .sub(/-\h{32}\.css$/, '.css').sub(/\A\//, '')
         end
       end
     end


### PR DESCRIPTION
Rails 3.2, development env

`/prefix/mailers.css` transform to `/mailers.css` and not find in assets, first slash removing fixing it