### PR TITLE
Cannot call Net::HTTP.get(uri) on URI::Generic

### DIFF
--- a/lib/premailer/rails/css_loaders/network_loader.rb
+++ b/lib/premailer/rails/css_loaders/network_loader.rb
@@ -18,6 +18,9 @@ class Premailer
             scheme = 'http' if scheme.blank?
             uri.scheme ||= scheme
             uri.host ||= host
+
+            # Cast what may be a URI::Generic to URI::HTTP
+            uri = URI(uri.to_s)
           end
 
           uri if valid_uri?(uri)

--- a/spec/unit/css_loaders/network_loader_spec.rb
+++ b/spec/unit/css_loaders/network_loader_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+describe Premailer::Rails::CSSLoaders::NetworkLoader do
+  before do
+    assets = double(prefix: '/assets')
+    action_controller = double(asset_host: 'http://assets.example.com')
+    config = double(assets: assets, action_controller: action_controller)
+    allow(Rails).to receive(:configuration).and_return(config)
+  end
+
+  describe ".uri_for_url" do
+    subject do
+      Premailer::Rails::CSSLoaders::NetworkLoader.uri_for_url(url)
+    end
+
+    context "for a schema-less url, responds_to method used internally" do
+      let(:url) { '//assets.example.com/assets/application.css' }
+      it { is_expected.to respond_to(:request_uri) }
+    end
+
+  end
+end


### PR DESCRIPTION
If a URI is created without a scheme, it does not respond_to request_uri which is called when instantiating a NetHTTP.get call.
Re-casting as a new URI after updating host and scheme fixes this. See #116
