### PR TITLE
Guard agains nil content type in Hook#pure_html_message?

### DIFF
--- a/lib/premailer/rails/hook.rb
+++ b/lib/premailer/rails/hook.rb
@@ -42,7 +42,7 @@ class Premailer
       # Returns true if the message itself has a content type of text/html, thus
       # it does not contain other parts such as alternatives and attachments.
       def pure_html_message?
-        message.content_type.include?('text/html')
+        message.content_type && message.content_type.include?('text/html')
       end
 
       def generate_html_part_replacement


### PR DESCRIPTION
Prevents premailer from breaking in the unlikely event that content type is `nil`.

This would probably only happen when relaying email from an outside source, and the sender's email client leaves the content type unset. In my case, it just made me realize that I should have been using `:skip_premailer` in that particular mailer. ;) Still, I thought I'd contribute with a fix.
