### PR TITLE
Fix loading premailer after rails has initialized

### DIFF
--- a/lib/premailer/rails.rb
+++ b/lib/premailer/rails.rb
@@ -6,7 +6,6 @@ require 'premailer/rails/css_loaders'
 require 'premailer/rails/css_helper'
 require 'premailer/rails/customized_premailer'
 require 'premailer/rails/hook'
-require 'premailer/rails/railtie' if defined?(Rails)
 
 class Premailer
   module Rails
@@ -27,3 +26,5 @@ class Premailer
     end
   end
 end
+
+require 'premailer/rails/railtie' if defined?(Rails)


### PR DESCRIPTION
Hi - if you require premailer-rails after Rails has initialized, it tries to call `Premailer::Rails.register_interceptors` before that method has been defined.  This PR moves the railtie to after the Premailer::Rails module definition.  WDYT?