### PR TITLE
Compatibility with Sprockets 3 (64 chars fingerprint)

### DIFF
--- a/lib/premailer/rails/css_loaders/asset_pipeline_loader.rb
+++ b/lib/premailer/rails/css_loaders/asset_pipeline_loader.rb
@@ -19,7 +19,7 @@ class Premailer
         def file_name(url)
           URI(url).path
             .sub("#{::Rails.configuration.assets.prefix}/", '')
-            .sub(/-\h{32}\.css$/, '.css')
+            .sub(/-(\h{32}|\h{64})\.css$/, '.css')
         end
       end
     end

--- a/spec/unit/css_loaders/asset_pipeline_loader_spec.rb
+++ b/spec/unit/css_loaders/asset_pipeline_loader_spec.rb
@@ -17,8 +17,13 @@ describe Premailer::Rails::CSSLoaders::AssetPipelineLoader do
       it { is_expected.to eq('application.css') }
     end
 
-    context "when asset file path contains fingerprint" do
+    context "when asset file path contains 32 chars fingerprint" do
       let(:asset) { 'application-6776f581a4329e299531e1d52aa59832.css' }
+      it { is_expected.to eq('application.css') }
+    end
+
+    context "when asset file path contains 64 chars fingerprint" do
+      let(:asset) { 'application-02275ccb3fd0c11615bbfb11c99ea123ca2287e75045fe7b72cefafb880dad2b.css' }
       it { is_expected.to eq('application.css') }
     end
 


### PR DESCRIPTION
Fixes #137.

[Sprockets 3 uses SHA256 digests](https://github.com/rails/sprockets/blob/master/CHANGELOG.md), meaning that the fingerprint contains 64 characters.
