### PR TITLE
Checking if Rails respond to :env

### DIFF
--- a/lib/premailer/rails/css_loaders/cache_loader.rb
+++ b/lib/premailer/rails/css_loaders/cache_loader.rb
@@ -11,7 +11,7 @@ class Premailer
         end
 
         def development_env?
-          defined?(::Rails) and ::Rails.env.development?
+          defined?(::Rails) and ::Rails.respond_to?(:env) and ::Rails.env.development?
         end
       end
     end


### PR DESCRIPTION
I'm using this gem with a non rails project and this PR tries to fix this exception:

```ruby
NoMethodError: undefined method `env' for Rails:Module
```