### PR TITLE
Ensure content-transfer-encoding is maintained

### DIFF
--- a/lib/premailer/rails/hook.rb
+++ b/lib/premailer/rails/hook.rb
@@ -68,15 +68,17 @@ class Premailer
       def generate_html_part
         # Make sure that the text part is generated first. Otherwise the text
         # can end up containing CSS rules.
-        generate_text_part  if generate_text_part?
+        generate_text_part if generate_text_part?
 
         Mail::Part.new(
+          content_transfer_encoding: html_part.content_transfer_encoding,
           content_type: "text/html; charset=#{html_part.charset}",
           body: premailer.to_inline_css)
       end
 
       def generate_text_part
         @text_part ||= Mail::Part.new(
+          content_transfer_encoding: html_part.content_transfer_encoding,
           content_type: "text/plain; charset=#{html_part.charset}",
           body: premailer.to_plain_text)
       end

--- a/spec/integration/hook_spec.rb
+++ b/spec/integration/hook_spec.rb
@@ -43,6 +43,17 @@ describe Premailer::Rails::Hook do
     expect(processed_message.parts).to match_array(expected_parts)
   end
 
+  describe 'when the content-transfer-encoding is set' do
+    before { message.content_transfer_encoding = 'quoted-printable' }
+
+    it 'should maintain the value' do
+      expect(processed_message.parts.first.content_transfer_encoding).to \
+        eq 'quoted-printable'
+      expect(processed_message.parts.last.content_transfer_encoding).to \
+        eq 'quoted-printable'
+    end
+  end
+
   it 'generates a text part from the html' do
     expect { run_hook(message) }.to change(message, :text_part)
   end


### PR DESCRIPTION
If the content-transfer-encoding has been set on the message, it should be maintained when generating new parts, otherwise the Mail gem (finding a nil value) will automatically set it to 7-bit.

Actionmailer tends to favour "quoted-printable" so that messages with lines over 998 characters don't get a line break in places that can break the content but this method would also allow a defined value in Actionmailer of something like base64 to be maintained too.