### PR TITLE
Add bin/rails to get the server to start

### DIFF
--- a/example/bin/rails
+++ b/example/bin/rails
@@ -1,0 +1,4 @@
+#!/usr/bin/env ruby
+APP_PATH = File.expand_path('../../config/application', __FILE__)
+require_relative '../config/boot'
+require 'rails/commands'


### PR DESCRIPTION
Hi Philipe,

I was pulling down the repo to check out the example, but I was unable to get the server running as it was. It bundled successfully but afterwards, I always ended up getting the following in the CLI:

```bash
$ rails s
Usage:
  rails new APP_PATH [options]

Options:
  [...]
```

After I added the default `bin/rails` file – the one that you get after running `rails new` – it ran just fine. Hope this will help other people spin up the example.

Cheers
Patrik