### PR TITLE
Use hpricot to remove stylesheet links from document instead of nokogiri

### DIFF
--- a/lib/premailer/rails/css_helper.rb
+++ b/lib/premailer/rails/css_helper.rb
@@ -27,7 +27,7 @@ class Premailer
 
       def css_urls_in_doc(doc)
         doc.search('link[@rel="stylesheet"]').map do |link|
-          link.remove
+          link.parent.children.delete(link)
           link.attributes['href'].to_s
         end
       end


### PR DESCRIPTION
This is a fix for issue #149 

Unfortunately removing hpricot from my project isn't possible quite yet. Thanks!
