### PR TITLE
Respect data-premailer="ignore" on link tags

### DIFF
--- a/lib/premailer/rails/css_helper.rb
+++ b/lib/premailer/rails/css_helper.rb
@@ -26,7 +26,7 @@ class Premailer
       private
 
       def css_urls_in_doc(doc)
-        doc.search('link[@rel="stylesheet"]').map do |link|
+        doc.search('link[@rel="stylesheet"]:not([@data-premailer="ignore"])').map do |link|
           link.remove
           link.attributes['href'].to_s
         end

--- a/spec/integration/css_helper_spec.rb
+++ b/spec/integration/css_helper_spec.rb
@@ -39,6 +39,15 @@ describe Premailer::Rails::CSSHelper do
         expect(css_for_doc(doc)).to eq("content of base.css\ncontent of font.css")
       end
     end
+
+    context 'when HTML contains ignored links' do
+      let(:files) { ['ignore.css', 'data-premailer' => 'ignore'] }
+
+      it 'ignores links' do
+        expect(Premailer::Rails::CSSHelper).to_not receive(:css_for_url)
+        css_for_doc(doc)
+      end
+    end
   end
 
   describe '#css_for_url' do

--- a/spec/support/fixtures/html.rb
+++ b/spec/support/fixtures/html.rb
@@ -18,17 +18,21 @@ module Fixtures
 </html>
     HTML
 
-    LINK = <<-LINK
-<link rel='stylesheet' href='%s' />
-    LINK
+    LINK = "<link rel='stylesheet' %s />\n"
 
     def with_css_links(*files)
+      opts = files.last.is_a?(Hash) ? files.pop : {}
       links = []
       files.each do |file|
-        links << LINK % "http://example.com/#{file}"
+        attrs = { href: "http://example.com/#{file}" }.merge(opts)
+        links << LINK % hash_to_attributes(attrs)
       end
 
       TEMPLATE % links.join
+    end
+
+    def hash_to_attributes(attrs)
+      attrs.map { |attr, value| "#{attr}='#{value}'" }.join(' ')
     end
   end
 end


### PR DESCRIPTION
I was working on a project that used a link tag to Google fonts, and I wanted to see if I could resolve #150. I changed the CSS selector used to search for link tags to `link[@rel='stylesheet']:not([@data-premailer='ignore'])` as [used in premailer](https://github.com/premailer/premailer/blob/8209d4bbd72200b0302eb8dcbd1c7ce8ab660057/lib/premailer/premailer.rb#L288). I also added a test for this behavior. 