### PR TITLE
Fix loading protocol-relative URLs over a network

### DIFF
--- a/lib/premailer/rails/css_loaders/network_loader.rb
+++ b/lib/premailer/rails/css_loaders/network_loader.rb
@@ -14,7 +14,7 @@ class Premailer
 
           if uri.host.present?
             return uri if uri.scheme.present?
-            URI("http://#{uri.to_s}")
+            URI::HTTP.build([uri.userinfo, uri.host, uri.port, uri.path, uri.query, uri.fragment])
           elsif asset_host_present?
             scheme, host = asset_host.split(%r{:?//})
             scheme, host = host, scheme if host.nil?

--- a/spec/unit/css_loaders/network_loader_spec.rb
+++ b/spec/unit/css_loaders/network_loader_spec.rb
@@ -18,7 +18,10 @@ describe Premailer::Rails::CSSLoaders::NetworkLoader do
 
     context 'with a protocol relative URL' do
       let(:url) { '//example.com/test.css' }
-      it { is_expected.to eq(URI("http://#{url}")) }
+      it { is_expected.to eq(URI("http:#{url}")) }
+      it 'has a hostname' do
+        expect(subject.hostname).to be_present
+      end
     end
 
     context 'with a file path' do


### PR DESCRIPTION
Previously, protocol-relative URLs such as "//www.example.com/foo.css"
would throw an error when loaded. This is due to a subtle issue with
URI parsing in the stardard library, bordering on a bug, where URI()
would appear to parse something like "http:////www.example.com" in a
sane manner, but actually would not set URI#hostname, and potentially
other methods, nor would it pass equality (`==`) with
"http://www.example.com"

This fixes the issue by building the URI more manually. Note, in Ruby
2.3 we could have used URI::join, but this particular case fails in Ruby
2.1 using URI::join.