### PR TITLE
Pass the asset path to asset_host when it responds to :call

### DIFF
--- a/lib/premailer/rails/css_loaders/network_loader.rb
+++ b/lib/premailer/rails/css_loaders/network_loader.rb
@@ -16,7 +16,7 @@ class Premailer
             return uri if uri.scheme.present?
             URI("http://#{uri.to_s}")
           elsif asset_host_present?
-            scheme, host = asset_host.split(%r{:?//})
+            scheme, host = asset_host(url).split(%r{:?//})
             scheme, host = host, scheme if host.nil?
             scheme = 'http' if scheme.blank?
             path = url
@@ -28,9 +28,9 @@ class Premailer
           ::Rails.configuration.action_controller.asset_host.present?
         end
 
-        def asset_host
+        def asset_host(url)
           config = ::Rails.configuration.action_controller.asset_host
-          config.respond_to?(:call) ? config.call : config
+          config.respond_to?(:call) ? config.call(url) : config
         end
       end
     end

--- a/spec/unit/css_loaders/network_loader_spec.rb
+++ b/spec/unit/css_loaders/network_loader_spec.rb
@@ -39,9 +39,14 @@ describe Premailer::Rails::CSSLoaders::NetworkLoader do
         it { is_expected.to eq(URI("http://example.com/assets/foo.css")) }
       end
 
-      context 'and a proc as asset host' do
-        let(:asset_host) { ->{ 'example.com' } }
-        it { is_expected.to eq(URI("http://example.com/assets/foo.css")) }
+      context 'and a callable object as asset host' do
+        let(:asset_host) { double }
+
+        it 'calls #call with the asset path as argument' do
+          expect(asset_host).to receive(:call).with(url).and_return(
+            'http://example.com')
+          expect(subject).to eq(URI('http://example.com/assets/foo.css'))
+        end
       end
 
       context 'without an asset host' do


### PR DESCRIPTION
`asset_host` isn't necessarily a `Proc`. [It actually can be any object that responds to `call`](https://github.com/rails/rails/blob/a611a813584a92fb59be107473971f896132121d/actionview/lib/action_view/helpers/asset_url_helper.rb#L197-201). And usually implementations of `call` require the `source` argument because [Rails always pass it](https://github.com/rails/rails/blob/a611a813584a92fb59be107473971f896132121d/actionview/lib/action_view/helpers/asset_url_helper.rb#L207-L214), even as a blank string. 

Since right now `premailer-rails` currently simply calls `call` with no arguments, non-proc objects that expects the `source` currently raise `ArgumentError` whenever `NetworkLoader` is used.

This PR addresses this issue by sending the asset path as argument when `asset_host` is called.