### PR TITLE
confirm file is a file and not directory before attempting to read.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Add support for rails' `relative_url_root` config
 - Fix link tag removal under Hpricot
 - Pass url to `asset_host` if it responds to `call`
+- Fixed issue where urls may conflict with folder names.
 
 ## v1.9.2
 

--- a/lib/premailer/rails/css_loaders/file_system_loader.rb
+++ b/lib/premailer/rails/css_loaders/file_system_loader.rb
@@ -7,7 +7,7 @@ class Premailer
         def load(url)
           path = URI(url).path
           file_path = "public#{path}"
-          File.read(file_path) if File.exist?(file_path)
+          File.read(file_path) if File.file?(file_path)
         end
       end
     end


### PR DESCRIPTION
**Issue**
When including remote css ie.
http://fonts.googleapis.com/css?family=Open+Sans:400italic,600italic,400,600
 
Module would attempt to map and read _/public/css_ as file.

This in turn would cause an error to be thrown particularly:
```
Errno::EISDIR: Is a directory - public/css (if public/css already existed)
```
**Resolution**
Resolved by confirming that File is a file and not a directory before reading file. 

Only tested in Rails 3.2.8, ruby 1.9.3p551