### PR TITLE
Improve check for Rails module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## HEAD
+
+- Improve check for Rails module
+
 ## v1.9.3
 
 - Add support for rails' `relative_url_root` config

--- a/lib/premailer/rails/css_loaders/asset_pipeline_loader.rb
+++ b/lib/premailer/rails/css_loaders/asset_pipeline_loader.rb
@@ -14,6 +14,7 @@ class Premailer
 
         def asset_pipeline_present?
           defined?(::Rails) &&
+            ::Rails.respond_to?(:application) &&
             ::Rails.application.respond_to?(:assets) &&
             ::Rails.application.assets
         end

--- a/lib/premailer/rails/css_loaders/cache_loader.rb
+++ b/lib/premailer/rails/css_loaders/cache_loader.rb
@@ -19,7 +19,9 @@ class Premailer
         end
 
         def development_env?
-          defined?(::Rails) && ::Rails.env.development?
+          defined?(::Rails) &&
+            ::Rails.respond_to?(:env) &&
+            ::Rails.env.development?
         end
       end
     end

--- a/lib/premailer/rails/css_loaders/network_loader.rb
+++ b/lib/premailer/rails/css_loaders/network_loader.rb
@@ -25,7 +25,8 @@ class Premailer
         end
 
         def asset_host_present?
-          ::Rails.configuration.action_controller.asset_host.present?
+          ::Rails.respond_to?(:configuration) &&
+            ::Rails.configuration.action_controller.asset_host.present?
         end
 
         def asset_host(url)


### PR DESCRIPTION
Just extended the check for Rails module, basically checking if it responds to `application` `configuration` and `env` ... :tada: 