### PR TITLE
Fix html part body encoding mismatch

### DIFF
--- a/lib/premailer/rails/hook.rb
+++ b/lib/premailer/rails/hook.rb
@@ -73,7 +73,7 @@ class Premailer
         Mail::Part.new(
           content_transfer_encoding: html_part.content_transfer_encoding,
           content_type: "text/html; charset=#{html_part.charset}",
-          body: premailer.to_inline_css)
+          body: premailer.to_inline_css).tap { |part| part.body.encoding = html_part.body.encoding }
       end
 
       def generate_text_part


### PR DESCRIPTION
We're experiencing an issue where non-romanic languages (greek, arabic, etc.) are being mangled when adding inline styles. Sample output here:

```
----==_mimepart_576da8cc3ec0f_33f92b29ed124970b9
Content-Type: text/html;
 charset=UTF-8
Content-Transfer-Encoding: base64

DOCTYPEHTMLhtmlheadmetahttpequivContentTypeconteng==

----==_mimepart_576da8cc3ec0f_33f92b29ed124970b9--
```

In the mail client:
![screen shot 2016-06-24 at 5 40 57 pm](https://cloud.githubusercontent.com/assets/750477/16351345/dd41f71c-3a32-11e6-9b62-c32068358323.png)

I'm fairly certain this is because, when creating a new `Mail::Part` in `generate_html_part`, the encoding of the body is not preserved. More info here: https://github.com/loomio/loomio/issues/3442