### PR TITLE
Update README on premailer Adapters

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,16 @@ If both gems are loaded for some reason, premailer chooses hpricot.
 
 That's it!
 
+## Adapters
+
+If you want to use a different adapter other than nokogiri, add the following line to `config/initializers/premailer_rails.rb`. 
+
+```ruby
+Premailer::Adapter.use = :nokogiri_fast
+```
+
+For more about adapters, refer to premailer [documentation](https://github.com/premailer/premailer#adapters).
+
 ## Configuration
 
 Premailer itself accepts a number of options. In order for premailer-rails to


### PR DESCRIPTION
I recently submitted a pull request to premailer gem adding a new adapter called NokogiriFast. It improves the inlining process by 20x with a proactive indexing technique. More description is on the pull request.

https://github.com/premailer/premailer/pull/332
https://github.com/premailer/premailer/pull/333

Let me know if you have any questions/comments, I will happy to address/clarify!

Thanks