### PR TITLE
Use the absolute path with Rails.root to find asset path

### DIFF
--- a/lib/premailer/rails/css_loaders/file_system_loader.rb
+++ b/lib/premailer/rails/css_loaders/file_system_loader.rb
@@ -14,7 +14,15 @@ class Premailer
           if relative_url_root
             path = path.sub(/\A#{relative_url_root.chomp('/')}/, '')
           end
-          "public#{path}"
+          asset_filename(path)
+        end
+
+        def asset_filename(filename)
+          if defined?(::Rails) && ::Rails.respond_to?(:root)
+            File.join(::Rails.root, 'public', filename)
+          else
+            File.join('public', filename)
+          end
         end
 
         def relative_url_root

--- a/spec/unit/css_loaders/file_system_loader_spec.rb
+++ b/spec/unit/css_loaders/file_system_loader_spec.rb
@@ -4,6 +4,8 @@ describe Premailer::Rails::CSSLoaders::FileSystemLoader do
   before do
     allow(Rails.configuration)
       .to receive(:assets).and_return(double(prefix: '/assets'))
+    allow(Rails)
+      .to receive(:root).and_return(Pathname.new('/rails_root'))
   end
 
   describe '#file_name' do
@@ -17,19 +19,19 @@ describe Premailer::Rails::CSSLoaders::FileSystemLoader do
 
     context 'when relative_url_root is not set' do
       let(:asset) { '/assets/application.css' }
-      it { is_expected.to eq('public/assets/application.css') }
+      it { is_expected.to eq(File.join(Rails.root, 'public/assets/application.css')) }
     end
 
     context 'when relative_url_root is set' do
       let(:relative_url_root) { '/foo' }
       let(:asset) { '/foo/assets/application.css' }
-      it { is_expected.to eq('public/assets/application.css') }
+      it { is_expected.to eq(File.join(Rails.root, 'public/assets/application.css')) }
     end
 
     context 'when relative_url_root has a trailing slash' do
       let(:relative_url_root) { '/foo/' }
       let(:asset) { '/foo/assets/application.css' }
-      it { is_expected.to eq('public/assets/application.css') }
+      it { is_expected.to eq(File.join(Rails.root, 'public/assets/application.css')) }
     end
   end
 end


### PR DESCRIPTION
If the current working directory of the application is not the Rails.root,
FileSystemLoader will quietly fail and fall back to the other CSS loaders,
which may not be desired.

Closes #194