### PR TITLE
[BUG] Fix port clobbering

### DIFF
--- a/lib/premailer/rails/css_loaders/network_loader.rb
+++ b/lib/premailer/rails/css_loaders/network_loader.rb
@@ -14,7 +14,7 @@ class Premailer
 
           if uri.host.present?
             return uri if uri.scheme.present?
-            URI("http://#{uri.to_s}")
+            URI("http:#{uri}")
           elsif asset_host_present?
             scheme, host = asset_host(url).split(%r{:?//})
             scheme, host = host, scheme if host.nil?

--- a/spec/unit/css_loaders/network_loader_spec.rb
+++ b/spec/unit/css_loaders/network_loader_spec.rb
@@ -18,7 +18,7 @@ describe Premailer::Rails::CSSLoaders::NetworkLoader do
 
     context 'with a protocol relative URL' do
       let(:url) { '//example.com/test.css' }
-      it { is_expected.to eq(URI("http://#{url}")) }
+      it { is_expected.to eq(URI("http:#{url}")) }
     end
 
     context 'with a file path' do


### PR DESCRIPTION
If the URL is a protocol relative, you are still clobbering the port because the URI call becomes `URI("http:////thing:3000")`. This confuses URI and causes it to drop the port.

```ruby
uri = uri_for_url("//blah.zab:3000")
uri.port = 80
```

#### TODO:
- [x] Spec for use case above