### PR TITLE
Use Rails.application.assets_manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## HEAD
 
 - Drop support for hpricot now that premailer-rails also doesn't support it
+- Use `Rails.application.assets_manifest` instead of `Rails.application.assets` in Asset Pipeline loader (@kirs, #201)
 
 ## v1.9.7
 

--- a/lib/premailer/rails/css_loaders/asset_pipeline_loader.rb
+++ b/lib/premailer/rails/css_loaders/asset_pipeline_loader.rb
@@ -5,18 +5,11 @@ class Premailer
         extend self
 
         def load(url)
-          if asset_pipeline_present?
-            file = file_name(url)
-            asset = ::Rails.application.assets.find_asset(file)
-            asset.to_s if asset
-          end
-        end
+          return unless asset_pipeline_present?
 
-        def asset_pipeline_present?
-          defined?(::Rails) &&
-            ::Rails.respond_to?(:application) &&
-            ::Rails.application.respond_to?(:assets) &&
-            ::Rails.application.assets
+          file = file_name(url)
+          ::Rails.application.assets_manifest.find_sources(file).first
+        rescue Errno::ENOENT => _error
         end
 
         def file_name(url)
@@ -28,6 +21,10 @@ class Premailer
           URI(url).path
             .sub(/\A#{prefix}/, '')
             .sub(/-(\h{32}|\h{64})\.css\z/, '.css')
+        end
+
+        def asset_pipeline_present?
+          defined?(::Rails) && ::Rails.application && ::Rails.application.assets_manifest
         end
       end
     end


### PR DESCRIPTION
First of all, thank you for creating and maintaining the library. We actively use at Shopify ❤️ 

This PR fixes a bug that we recently discovered. We found that with precompiled assets and `config.assets.compile = false` option in production, `Rails.application.assets` would always be `nil`. That makes `AssetPipelineLoader` simply useless. As soon as we disabled asset compilation in production, premailer broke and styles were no longer inlined.

The proper way to discover assets would be to use `Rails.application.assets_manifest`. It works both in development (with compile-on-the-fly) and in production (with precompiled assets and the manifest).

@fphilipe let me know what you think about the patch.
cc @rafaelfranca 