### PR TITLE
Fix failing test (sort content types)

### DIFF
--- a/spec/integration/hook_spec.rb
+++ b/spec/integration/hook_spec.rb
@@ -91,7 +91,7 @@ describe Premailer::Rails::Hook do
 
     it 'does not replace any message part' do
       expect { run_hook(message) }.to_not \
-        change { message.all_parts.map(&:content_type) }
+        change { message.all_parts.map(&:content_type).sort }
     end
   end
 


### PR DESCRIPTION
There is a test that started failing on master:

```
$ premailer-rails (master|…) $ env ACTION_MAILER_VERSION=4 bundle exec rspec spec/integration/hook_spec.rb:95
Run options: include {:locations=>{"./spec/integration/hook_spec.rb"=>[95]}}

Premailer::Rails::Hook
  when message also contains a text part
    does not replace any message part (FAILED - 1)

Failures:

  1) Premailer::Rails::Hook when message also contains a text part does not replace any message part
     Failure/Error:
       expect { run_hook(message) }.to_not \
         change { message.all_parts.map(&:content_type) }

       expected `message.all_parts.map(&:content_type)` not to have changed, but did change from ["multipart/alternative; boundary=\"--==_mimepart_59fefc1f62087_b113fe7bb43f93096866\"; charset=UTF-8", "text/html; charset=UTF-8", "text/plain; charset=UTF-8"] to ["multipart/alternative; boundary=\"--==_mimepart_59fefc1f62087_b113fe7bb43f93096866\"; charset=UTF-8", "text/plain; charset=UTF-8", "text/html; charset=UTF-8"]
     # ./spec/integration/hook_spec.rb:93:in `block (3 levels) in <top (required)>'

Finished in 0.25537 seconds (files took 0.55858 seconds to load)
1 example, 1 failure

Failed examples:

rspec ./spec/integration/hook_spec.rb:92 # Premailer::Rails::Hook when message also contains a text part does not replace any message part
```

This PR tries to fix that test by sorting content types before comparing them.