### PR TITLE
Ignore .ruby-version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 doc/
 Gemfile.lock
 coverage/
+.ruby-version


### PR DESCRIPTION
.ruby-version is useful in development. Let's add it to gitignore.
