### PR TITLE
Fix TypeError on production environment with non existing asset

### DIFF
--- a/lib/premailer/rails/css_loaders/asset_pipeline_loader.rb
+++ b/lib/premailer/rails/css_loaders/asset_pipeline_loader.rb
@@ -8,7 +8,10 @@ class Premailer
           return unless asset_pipeline_present?
 
           file = file_name(url)
-          ::Rails.application.assets_manifest.find_sources(file).first
+          assets_manifest = ::Rails.application.assets_manifest
+          if assets_manifest.environment.present? || (assets_manifest.environment.nil? && assets_manifest.assets[file])
+            ::Rails.application.assets_manifest.find_sources(file).first
+          end
         rescue Errno::ENOENT => _error
         end
 

--- a/spec/integration/css_helper_spec.rb
+++ b/spec/integration/css_helper_spec.rb
@@ -113,6 +113,17 @@ describe Premailer::Rails::CSSHelper do
         end
       end
 
+      context 'and an environment is nil and an asset doesnt exist' do
+        it 'returns nil' do
+          allow(Rails.application.assets_manifest).to \
+            receive(:environment)
+              .and_return(nil)
+
+          expect { css_for_url('non_existent_path') }.to \
+            raise_error(Premailer::Rails::CSSHelper::FileNotFound)
+        end
+      end
+
       context "when find_sources raises Errno::ENOENT" do
         let(:response) { 'content of base.css' }
         let(:uri) { URI('http://example.com/assets/base.css') }


### PR DESCRIPTION
When running app with production environment it tries to load asset that doesn't exist in pipeline, it raises TypeError. 

I ran into it when I had link to external css but AssetPipelineLoader tried to fetch it first and raised  TypeError. 

