### PR TITLE
Rescue TypeError from Sprockets

### DIFF
--- a/lib/premailer/rails/css_loaders/asset_pipeline_loader.rb
+++ b/lib/premailer/rails/css_loaders/asset_pipeline_loader.rb
@@ -9,7 +9,7 @@ class Premailer
 
           file = file_name(url)
           ::Rails.application.assets_manifest.find_sources(file).first
-        rescue Errno::ENOENT => _error
+        rescue Errno::ENOENT, TypeError => _error
         end
 
         def file_name(url)

--- a/spec/integration/css_helper_spec.rb
+++ b/spec/integration/css_helper_spec.rb
@@ -113,6 +113,23 @@ describe Premailer::Rails::CSSHelper do
         end
       end
 
+      context "when find_sources raises TypeError" do
+        let(:response) { 'content of base.css' }
+        let(:uri) { URI('http://example.com/assets/base.css') }
+
+        it "falls back to Net::HTTP" do
+          expect(Rails.application.assets_manifest).to \
+            receive(:find_sources)
+              .with('base.css')
+              .and_raise(TypeError)
+
+          allow(Net::HTTP).to \
+            receive(:get).with(uri).and_return(response)
+          expect(css_for_url('http://example.com/assets/base.css')).to \
+            eq(response)
+        end
+      end
+
       context "when find_sources raises Errno::ENOENT" do
         let(:response) { 'content of base.css' }
         let(:uri) { URI('http://example.com/assets/base.css') }


### PR DESCRIPTION
This should fix https://github.com/fphilipe/premailer-rails/issues/207.

We are rescuing `Errno::ENOENT` in case Sprockets can't find that file, but we should also rescue `TypeError` that seems to pop up in that issues.