### PR TITLE
Require at least version 3 of sprockets-rails

### DIFF
--- a/premailer-rails.gemspec
+++ b/premailer-rails.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'premailer', '~> 1.7', '>= 1.7.9'
   s.add_dependency 'actionmailer', '>= 3', '< 6'
+  s.add_dependency 'sprockets-rails', '>= 3'
 
   s.add_development_dependency 'rspec', '~> 3.3'
   s.add_development_dependency 'nokogiri'


### PR DESCRIPTION
Please see https://github.com/fphilipe/premailer-rails/issues/211

I have required at least version 3 of sprockets-rails. Since version 3 of sprockets-rails support for version 4 of sprockets was added. The `Sprockets::Manifest#find_sources` method was only added in version 4 of sprockets (see this commit: https://github.com/rails/sprockets/commit/5785fd9d41f49f7763595d57908ce34e8f92e585) 