### PR TITLE
Explicitly check for assets_manifest

### DIFF
--- a/lib/premailer/rails/css_loaders/asset_pipeline_loader.rb
+++ b/lib/premailer/rails/css_loaders/asset_pipeline_loader.rb
@@ -24,7 +24,10 @@ class Premailer
         end
 
         def asset_pipeline_present?
-          defined?(::Rails) && ::Rails.application && ::Rails.application.assets_manifest
+          defined?(::Rails) &&
+            ::Rails.application &&
+            ::Rails.application.respond_to?(:assets_manifest) &&
+            ::Rails.application.assets_manifest
         end
       end
     end


### PR DESCRIPTION
If 'sprockets/railtie' is not loaded, ```AssetPipelineLoader#asset_pipeline_present?``` will blow up trying to call ```#assets_manifest``` on ```Rails.application```.

See https://github.com/fphilipe/premailer-rails/issues/213