### PR TITLE
Remove upperbound constraint on ActionMailer, Rails 6 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,3 @@ env:
     - ACTION_MAILER_VERSION=4
     - ACTION_MAILER_VERSION=5
     - ACTION_MAILER_VERSION=master
-matrix:
-  fast_finish: true
-  allow_failures:
-    - env: ACTION_MAILER_VERSION=master

--- a/premailer-rails.gemspec
+++ b/premailer-rails.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency 'premailer', '~> 1.7', '>= 1.7.9'
-  s.add_dependency 'actionmailer', '>= 3', '< 6'
+  s.add_dependency 'actionmailer', '>= 3'
 
   s.add_development_dependency 'rspec', '~> 3.3'
   s.add_development_dependency 'nokogiri'


### PR DESCRIPTION
Instead of updating the gemspec with every release we can be less
conservative. As a result makes master check on CI mandatory