### PR TITLE
Loosen dependency on actionmailer for Rails 6

### DIFF
--- a/premailer-rails.gemspec
+++ b/premailer-rails.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency 'premailer', '~> 1.7', '>= 1.7.9'
-  s.add_dependency 'actionmailer', '>= 3', '< 6'
+  s.add_dependency 'actionmailer', '>= 3', '< 7'
 
   s.add_development_dependency 'rspec', '~> 3.3'
   s.add_development_dependency 'nokogiri'


### PR DESCRIPTION
I have run the specs against Rails 6.0.0.beta3 and the current
rails/master branch and the test suite is still green.