### PR TITLE
Update sprockets requirements

### DIFF
--- a/premailer-rails.gemspec
+++ b/premailer-rails.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'premailer', '~> 1.7', '>= 1.7.9'
   s.add_dependency 'actionmailer', '>= 3', '< 6'
+  s.add_dependency 'sprockets', '>= 3'
 
   s.add_development_dependency 'rspec', '~> 3.3'
   s.add_development_dependency 'nokogiri'


### PR DESCRIPTION
Sprockets 2 does not work with this gem, so make sure to specify that.

One thing that is worthy of discussion is that this makes the requirement for sprockets explicit, whereas before it was "dynamic" to whether sprockets existed or not. Unsure if that was intentional, and if it was then this is probably not going to work.