### PR TITLE
Rails 6.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ env:
   matrix:
     - ACTION_MAILER_VERSION=4
     - ACTION_MAILER_VERSION=5
+    - ACTION_MAILER_VERSION=6.0.0.beta3
     - ACTION_MAILER_VERSION=master
 matrix:
   fast_finish: true

--- a/premailer-rails.gemspec
+++ b/premailer-rails.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency 'premailer', '~> 1.7', '>= 1.7.9'
-  s.add_dependency 'actionmailer', '>= 3', '< 6'
+  s.add_dependency 'actionmailer', '>= 3', '< 6.1'
 
   s.add_development_dependency 'rspec', '~> 3.3'
   s.add_development_dependency 'nokogiri'


### PR DESCRIPTION
This basically bumps the allowed `actionmailer` versions to everything below `6.1`.

Specs are running fine locally with `ACTION_MAILER_VERSION=6.0.0.beta3`