### PR TITLE
Fix encoding

### DIFF
--- a/lib/premailer/rails/hook.rb
+++ b/lib/premailer/rails/hook.rb
@@ -73,10 +73,8 @@ class Premailer
         part = html_part
         html = premailer.to_inline_css
         Mail::Part.new do
-          content_transfer_encoding part.content_transfer_encoding
-          content_type "text/html; charset=#{part.charset}"
+          content_type "text/html; charset=#{html.encoding}"
           body html
-          body_encoding part.body.encoding
         end
       end
 
@@ -85,10 +83,8 @@ class Premailer
           part = html_part
           text = premailer.to_plain_text
           Mail::Part.new do
-            content_transfer_encoding part.content_transfer_encoding
-            content_type "text/plain; charset=#{part.charset}"
+            content_type "text/plain; charset=#{text.encoding}"
             body text
-            body_encoding part.body.encoding
           end
         end
       end

--- a/spec/support/fixtures/message.rb
+++ b/spec/support/fixtures/message.rb
@@ -35,6 +35,30 @@ module Fixtures
 </html>
     HTML
 
+    HTML_PART_IN_GREEK = <<-HTML.encode(Encoding::ISO_8859_7)
+<html>
+  <head>
+  </head>
+  <body>
+    <p>
+      Αα Ββ Γγ Δδ Εε Ζζ Ηη Θθ Ιι Κκ Λλ Μμ Νν Ξξ Οο Ππ Ρρ Σσ Ττ Υυ Φφ Χχ Ψψ Ωω
+    </p>
+  </body>
+</html>
+    HTML
+
+    HTML_PART_WITH_DASHES = <<-HTML
+<html>
+  <head>
+  </head>
+  <body>
+    <p>
+      Hello there—yes you! What's up with – pardon the interrupion – dashes? I can also do &ndash; and &mdash;.
+    </p>
+  </body>
+</html>
+    HTML
+
     HTML_PART_WITH_CSS = <<-HTML
 <html>
   <head>
@@ -125,6 +149,22 @@ nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
     def non_latin_message
       base_message.tap do |message|
         message.body = HTML_PART_WITH_UNICODE
+        message.content_type 'text/html; charset=UTF-8'
+        message.ready_to_send!
+      end
+    end
+
+    def greek_message
+      base_message.tap do |message|
+        message.body = HTML_PART_IN_GREEK
+        message.content_type 'text/html; charset=ISO-8859-7'
+        message.ready_to_send!
+      end
+    end
+
+    def dash_message
+      base_message.tap do |message|
+        message.body = HTML_PART_WITH_DASHES
         message.content_type 'text/html; charset=UTF-8'
         message.ready_to_send!
       end


### PR DESCRIPTION
After extensive testing, there should be no need to mess with the transfer encoding or the body encoding. All we need to ensure is that the proper charset is configured in the `Content-Type` header when assigning the body, which needs to be the encoding of the string being set as the body.

Fixes #240