### PR TITLE
Update CI with current versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: ruby
 cache: bundler
 script: bundle exec rspec
 rvm:
-  - 2.6.3
+  - 2.6.5
 env:
   matrix:
     - ACTION_MAILER_VERSION=4

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ env:
   matrix:
     - ACTION_MAILER_VERSION=4
     - ACTION_MAILER_VERSION=5
-    - ACTION_MAILER_VERSION=6.0.0.rc2
+    - ACTION_MAILER_VERSION=6
     - ACTION_MAILER_VERSION=master
 matrix:
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ rvm:
   - 2.7.0
 env:
   matrix:
-    - ACTION_MAILER_VERSION=4
     - ACTION_MAILER_VERSION=5
     - ACTION_MAILER_VERSION=6
     - ACTION_MAILER_VERSION=master

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ cache: bundler
 script: bundle exec rspec
 rvm:
   - 2.6.5
+  - 2.7.0
 env:
   matrix:
     - ACTION_MAILER_VERSION=4


### PR DESCRIPTION
Some small changes to keep the Travis CI configuration current. This does the following:
* Now building against ActionMailer 6 final version (not RC)
* Using latest patched Ruby 2.6.x version
* Added Ruby 2.7.0 to build matrix