### PR TITLE
Check that Rails.application is defined before calling

### DIFF
--- a/lib/premailer/rails/css_loaders/asset_pipeline_loader.rb
+++ b/lib/premailer/rails/css_loaders/asset_pipeline_loader.rb
@@ -25,6 +25,7 @@ class Premailer
 
         def asset_pipeline_present?
           defined?(::Rails) &&
+            ::Rails.respond_to?(:application) &&
             ::Rails.application &&
             ::Rails.application.respond_to?(:assets_manifest) &&
             ::Rails.application.assets_manifest


### PR DESCRIPTION
Check that `Rails.application` is defined before calling in on `AssetPipelineLoader`