### PR TITLE
Remove trailing slashes from relative_url_root

### DIFF
--- a/lib/premailer/rails/css_loaders/asset_pipeline_loader.rb
+++ b/lib/premailer/rails/css_loaders/asset_pipeline_loader.rb
@@ -13,11 +13,11 @@ class Premailer
         end
 
         def file_name(url)
-          prefix = [
-            ::Rails.configuration.relative_url_root,
-            ::Rails.configuration.assets.prefix,
+          prefix = File.join(
+            ::Rails.configuration.relative_url_root.to_s,
+            ::Rails.configuration.assets.prefix.to_s,
             '/'
-          ].join
+          )
           URI(url).path
             .sub(/\A#{prefix}/, '')
             .sub(/-(\h{32}|\h{64})\.css\z/, '.css')

--- a/spec/unit/css_loaders/asset_pipeline_loader_spec.rb
+++ b/spec/unit/css_loaders/asset_pipeline_loader_spec.rb
@@ -27,6 +27,16 @@ describe Premailer::Rails::CSSLoaders::AssetPipelineLoader do
       it { is_expected.to eq('application.css') }
     end
 
+    context "when asset file path contains prefix and relative_url_root is set to root" do
+      before do
+        allow(Rails.configuration)
+          .to receive(:relative_url_root).and_return('/')
+      end
+
+      let(:asset) { '/assets/application.css' }
+      it { is_expected.to eq('application.css') }
+    end
+
     context "when asset file path contains 32 chars fingerprint" do
       let(:asset) { 'application-6776f581a4329e299531e1d52aa59832.css' }
       it { is_expected.to eq('application.css') }


### PR DESCRIPTION
`Rails.configuration.relative_url_root` can be set to `/` and the
cleanup will fail because because the `prefix` is `//assets` instead
of `/assets`