### PR TITLE
Add Accept header to requests in NetworkLoader

### DIFF
--- a/lib/premailer/rails/css_loaders/network_loader.rb
+++ b/lib/premailer/rails/css_loaders/network_loader.rb
@@ -6,7 +6,7 @@ class Premailer
 
         def load(url)
           uri = uri_for_url(url)
-          Net::HTTP.get(uri) if uri
+          Net::HTTP.get(uri, { 'Accept' => 'text/css' }) if uri
         end
 
         def uri_for_url(url)


### PR DESCRIPTION
### Description 📖 

This pull request adds the `Accept` headers to requests made by the `NetworkLoader` strategy.

This allows development servers which can serve different file types—such as [Vite.js](https://vitejs.dev/)—to serve a CSS file as expected.

This change should be backwards-compatible as any server that was previously responding with CSS content should continue to do so.

### Background 📜 

[Vite.js](https://vitejs.dev/) can serve JS content for a given CSS file path, which allows it to provide hot-refresh for stylesheets.

For more information, see https://github.com/ElMassimo/vite_ruby/pull/93#issuecomment-865426710