### PR TITLE
Webpack support (revival of #255)

### DIFF
--- a/lib/premailer/rails/css_loaders/network_loader.rb
+++ b/lib/premailer/rails/css_loaders/network_loader.rb
@@ -14,6 +14,7 @@ class Premailer
 
           if uri.host.present?
             return uri if uri.scheme.present?
+
             URI("http:#{uri}")
           elsif asset_host_present?
             scheme, host = asset_host(url).split(%r{:?//})
@@ -21,6 +22,8 @@ class Premailer
             scheme = 'http' if scheme.blank?
             path = url
             URI(File.join("#{scheme}://#{host}", path))
+          else
+            URI(File.join(::Rails.application.routes.url_helpers.root_url, url))
           end
         end
 


### PR DESCRIPTION
As discussed in #232, Rails has now been supporting the use of webpack for assets management for quite a while.
It seems normal that the `premailer-rails` gem support a strategy to retrieve assets files (CSS) from webpacker directly.

Without this change, the current code cannot retrieve CSS stylesheets which are made available from webpack used in Rails.