### PR TITLE
align with rails maintained versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,14 +3,18 @@ language: ruby
 cache: bundler
 script: bundle exec rspec
 rvm:
-  - 2.6.5
-  - 2.7.0
+  - 2.5.9
+  - 2.6.8
+  - 2.7.4
+  - 3.0.2
 env:
   matrix:
-    - ACTION_MAILER_VERSION=5
-    - ACTION_MAILER_VERSION=6
-    - ACTION_MAILER_VERSION=master
+    - ACTION_MAILER_VERSION=5.2
+    - ACTION_MAILER_VERSION=6.0
+    - ACTION_MAILER_VERSION=6.1
+    - ACTION_MAILER_VERSION=6.2
+    - ACTION_MAILER_VERSION=main
 matrix:
   fast_finish: true
   allow_failures:
-    - env: ACTION_MAILER_VERSION=master
+    - env: ACTION_MAILER_VERSION=main

--- a/Gemfile
+++ b/Gemfile
@@ -1,24 +1,14 @@
 source 'https://rubygems.org'
+git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 gemspec
 
-rails_version = ENV.fetch('ACTION_MAILER_VERSION', '5')
+rails_version = ENV.fetch('ACTION_MAILER_VERSION', '6')
 
-if rails_version == 'master'
-  git 'git://github.com/rails/rails.git' do
-    gem 'rails'
-  end
-  gem 'sprockets-rails', github: 'rails/sprockets-rails'
-  gem 'arel', github: 'rails/arel'
+if rails_version == "main"
+  gem 'rails', github: "rails/rails", branch: :main
 else
   gem 'rails', "~> #{rails_version}"
 end
 
 gem 'byebug'
-
-platforms :rbx do
-  gem 'rubysl'
-  gem 'racc'
-end
-
-gem 'tins', '< 1.7' if RUBY_VERSION.split('.').first.to_i < 2

--- a/premailer-rails.gemspec
+++ b/premailer-rails.gemspec
@@ -1,6 +1,4 @@
-# -*- encoding: utf-8 -*-
-$:.push File.expand_path("../lib", __FILE__)
-require "premailer/rails/version"
+require_relative "lib/premailer/rails/version"
 
 Gem::Specification.new do |s|
   s.name        = "premailer-rails"
@@ -24,7 +22,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency 'premailer', '~> 1.7', '>= 1.7.9'
-  s.add_dependency 'actionmailer', '>= 3'
+  s.add_dependency 'actionmailer', '>= 5'
 
   s.add_development_dependency 'rspec', '~> 3.3'
   s.add_development_dependency 'nokogiri'


### PR DESCRIPTION
drop rubinius as it's not used and ruby versions:

https://www.fastruby.io/blog/ruby/rails/versions/compatibility-table.html

https://www.ruby-lang.org/en/downloads/releases/