### PR TITLE
Add "Ignore" CSS loading strategy to silently ignore any failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ available are:
     (and thus resulting in a smaller app) and deploy the assets to a CDN such
     as S3/CloudFront.
 
+-   `:ignore`: If all of the above fail, you may add `:ignore` at the end of the 
+    loading chain if you wish to silently ignore any failure.
+
 You can configure which strategies you want to use as well as specify their
 order. Refer to the *Configuration* section for more on this.
 

--- a/lib/premailer/rails/css_helper.rb
+++ b/lib/premailer/rails/css_helper.rb
@@ -59,6 +59,8 @@ class Premailer
           CSSLoaders::AssetPipelineLoader
         when :network
           CSSLoaders::NetworkLoader
+        when :ignore
+          CSSLoaders::IgnoreLoader
         else
           key
         end

--- a/lib/premailer/rails/css_loaders/ignore_loader.rb
+++ b/lib/premailer/rails/css_loaders/ignore_loader.rb
@@ -1,0 +1,13 @@
+class Premailer
+  module Rails
+    module CSSLoaders
+      module IgnoreLoader
+        extend self
+
+        def load(_url)
+          ''
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/css_loaders/ignore_loader_spec.rb
+++ b/spec/unit/css_loaders/ignore_loader_spec.rb
@@ -1,0 +1,8 @@
+require 'spec_helper'
+
+describe Premailer::Rails::CSSLoaders::IgnoreLoader do
+  describe '#load' do
+    subject { described_class.load('test') }
+    it { is_expected.to eq('') }
+  end
+end


### PR DESCRIPTION
In my app, I allow users to customize their mailer CSS and raw HTML. Sometimes they add in CSS <link> tags and I'd like to just ignore them.