### PR TITLE
Add net-http gem dependency to silence net-protocol warnings

### DIFF
--- a/premailer-rails.gemspec
+++ b/premailer-rails.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'premailer', '~> 1.7', '>= 1.7.9'
   s.add_dependency 'actionmailer', '>= 3'
   s.add_dependency 'net-smtp' if RUBY_VERSION >= '3'
+  s.add_dependency 'net-http' if RUBY_VERSION < '3'
 
   s.add_development_dependency 'rspec', '~> 3.3'
   s.add_development_dependency 'nokogiri'


### PR DESCRIPTION
Issue #279 

After the gem update to `v1.12.0`, we started to get below warnings on `net-protocol` gem.

This PR adds `net-http` to gem dependencies for earlier versions of Ruby v3 to silence these warnings as suggested in https://github.com/ruby/net-imap/issues/16

```
.rbenv/versions/2.7.5/lib/ruby/gems/2.7.0/gems/net-protocol-0.1.3/lib/net/protocol.rb:68: warning: already initialized constant Net::ProtocRetryError
.rbenv/versions/2.7.5/lib/ruby/2.7.0/net/protocol.rb:66: warning: previous definition of ProtocRetryError was here
.rbenv/versions/2.7.5/lib/ruby/gems/2.7.0/gems/net-protocol-0.1.3/lib/net/protocol.rb:208: warning: already initialized constant Net::BufferedIO::BUFSIZE
.rbenv/versions/2.7.5/lib/ruby/2.7.0/net/protocol.rb:206: warning: previous definition of BUFSIZE was here
.rbenv/versions/2.7.5/lib/ruby/gems/2.7.0/gems/net-protocol-0.1.3/lib/net/protocol.rb:504: warning: already initialized constant Net::NetPrivate::Socket
.rbenv/versions/2.7.5/lib/ruby/2.7.0/net/protocol.rb:503: warning: previous definition of Socket was here
```