### PR TITLE
Fix content-type checker

### DIFF
--- a/lib/premailer/rails/hook.rb
+++ b/lib/premailer/rails/hook.rb
@@ -42,7 +42,7 @@ class Premailer
       # Returns true if the message itself has a content type of text/html, thus
       # it does not contain other parts such as alternatives and attachments.
       def pure_html_message?
-        message.content_type && message.content_type.include?('text/html')
+        message.content_type && message.content_type.start_with?('text/html')
       end
 
       def generate_html_part_replacement
@@ -112,7 +112,7 @@ class Premailer
       # If the new part is a pure text/html part, the body and its content type
       # are used for the message. If the new part is
       def replace_in_pure_html_message(new_part)
-        if new_part.content_type.include?('text/html')
+        if new_part.content_type.start_with?('text/html')
           message.body = new_part.decoded
           message.content_type = new_part.content_type
         else

--- a/spec/integration/hook_spec.rb
+++ b/spec/integration/hook_spec.rb
@@ -144,6 +144,14 @@ describe Premailer::Rails::Hook do
         include 'multipart/alternative'
       expect(processed_message.parts.last.content_type).to include 'image/png'
     end
+
+    context 'with content-type "type" set' do
+        before { message.content_type += '; type="text/html"' }
+
+        it 'does not change content-type' do
+            expect(processed_message.content_type).to include 'multipart/mixed'
+        end
+    end
   end
 
   context 'when message has a skip premailer header' do


### PR DESCRIPTION
When having `type="text/html"` set inside content-type, it's being incorrectly detected as text/html.

Example: valid header `Content-Type: multipart/related; type="text/html"` being detected as pure HTML, causes an error

```
     Failure/Error: @premailer ||= CustomizedPremailer.new(html_part.decoded)

     NoMethodError:
       Can not decode an entire message, try calling #decoded on the various fields and body or parts if it is a multipart message.

               raise NoMethodError, 'Can not decode an entire message, try calling #decoded on the various fields and body or parts if it is a multipart message.'
               ^^^^^
```