### PR TITLE
Removes https get accept header when using Ruby version < 3.0

### DIFF
--- a/lib/premailer/rails/css_loaders/network_loader.rb
+++ b/lib/premailer/rails/css_loaders/network_loader.rb
@@ -6,7 +6,11 @@ class Premailer
 
         def load(url)
           uri = uri_for_url(url)
-          Net::HTTP.get(uri) if uri
+          if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("3.0.0")
+            Net::HTTP.get(uri, { 'Accept' => 'text/css' }) if uri
+          else
+            Net::HTTP.get(uri) if uri
+          end
         end
 
         def uri_for_url(url)

--- a/lib/premailer/rails/css_loaders/network_loader.rb
+++ b/lib/premailer/rails/css_loaders/network_loader.rb
@@ -6,7 +6,7 @@ class Premailer
 
         def load(url)
           uri = uri_for_url(url)
-          Net::HTTP.get(uri, { 'Accept' => 'text/css' }) if uri
+          Net::HTTP.get(uri) if uri
         end
 
         def uri_for_url(url)

--- a/spec/integration/css_helper_spec.rb
+++ b/spec/integration/css_helper_spec.rb
@@ -126,7 +126,6 @@ describe Premailer::Rails::CSSHelper do
 
             allow(Net::HTTP).to \
               receive(:get)
-                .with(uri, { 'Accept' => 'text/css' })
                 .and_return(response)
             expect(css_for_url('http://example.com/assets/base.css')).to \
               eq(response)
@@ -145,7 +144,6 @@ describe Premailer::Rails::CSSHelper do
 
             allow(Net::HTTP).to \
               receive(:get)
-                .with(uri, { 'Accept' => 'text/css' })
                 .and_return(response)
             expect(css_for_url('http://example.com/assets/base.css')).to \
               eq(response)
@@ -189,7 +187,6 @@ describe Premailer::Rails::CSSHelper do
 
             allow(Net::HTTP).to \
               receive(:get)
-                .with(URI(url), { 'Accept' => 'text/css' })
                 .and_return(response)
           end
 


### PR DESCRIPTION
This takes @lauratpa's original fix and adds tests — in this case easy to do since the calls that differ by Ruby version are all mocked. 