### PR TITLE
Allow HTTP strategy to ignore self signed SSL certificate

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,8 @@ configs are:
 {
   input_encoding: 'UTF-8',
   generate_text_part: true,
-  strategies: [:filesystem, :asset_pipeline, :network]
+  strategies: [:filesystem, :asset_pipeline, :network],
+  verify_ssl: true
 }
 ```
 

--- a/lib/premailer/rails.rb
+++ b/lib/premailer/rails.rb
@@ -12,7 +12,8 @@ class Premailer
     @config = {
       input_encoding: 'UTF-8',
       generate_text_part: true,
-      strategies: [:filesystem, :asset_pipeline, :propshaft, :network]
+      strategies: [:filesystem, :asset_pipeline, :propshaft, :network],
+      verify_ssl: true
     }
     class << self
       attr_accessor :config

--- a/lib/premailer/rails/css_loaders/network_loader.rb
+++ b/lib/premailer/rails/css_loaders/network_loader.rb
@@ -9,6 +9,25 @@ class Premailer
           Net::HTTP.get(uri, { 'Accept' => 'text/css' }) if uri
         end
 
+        def load(url)
+          uri = uri_for_url(url)
+
+          return unless uri
+
+          req = Net::HTTP::Get.new(uri.path, { 'Accept' => 'text/css' })
+          res = Net::HTTP.start(
+            uri.host,
+            uri.port, {
+              :use_ssl => uri.scheme == 'https',
+              :verify_mode => Premailer::Rails.config[:verify_ssl] == false ? OpenSSL::SSL::VERIFY_NONE : OpenSSL::SSL::VERIFY_PEER
+            }
+          ) do |https|
+            https.request(req)
+          end
+
+          res.body
+        end
+
         def uri_for_url(url)
           uri = URI(url)
 


### PR DESCRIPTION
We use this excellent gem for dealing with styles in our mailers using the HTTP strategy and to make all environments match production, in development, we proxy Rails with a local domain name with a self signed SSL certificate.

Currently `Net::HTTP` borks because it doesn't recognise our self signed certificate so in this PR we are adding a `verify_ssl` option to Premailer to bypass that verification step.